### PR TITLE
Support for Device Group's user-defined Environment Variables

### DIFF
--- a/lib/DeviceGroups.js
+++ b/lib/DeviceGroups.js
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017-2019 Electric Imp
+// Copyright 2017-2020 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -44,12 +44,14 @@ class DeviceGroups extends Entities {
         this._validCreateAttributes = {
             name : true,
             description : false,
-            region : false
+            region : false,
+            env_vars : false
         };
         this._validUpdateAttributes = {
             name : true,
             description : false,
-            load_code_after_blessing : false
+            load_code_after_blessing : false,
+            env_vars : false
         };
     }
 
@@ -155,6 +157,8 @@ class DeviceGroups extends Entities {
     //                                 'region' (String, optional) - a Device Group's region,
     //                                     May be specified if the new Device Group is of the production 
     //                                     or pre_production type only
+    //                                 'env_vars' (Object, optional) - user-defined Environment Variables
+    //                                     of the Device Group, Object containing key/value pairs
     //     productionTarget :      Optional production_target relationship of the Device Group to be
     //         Object              created. Must be specified for pre_factoryfixture and factoryfixture device groups.
     //                             The valid keys are:
@@ -246,6 +250,8 @@ class DeviceGroups extends Entities {
     //                                     connects as part of BlinkUp, whether successful or not.
     //                                     Valid for production and pre_production Device Groups only.
     //                                     Default value is true.
+    //                                 'env_vars' (Object, optional) - user-defined Environment Variables
+    //                                     of the Device Group, Object containing key/value pairs
     //     productionTarget :      Optional production_target relationship of the Device Group to be
     //         Object              updated. Can be specified for pre_factoryfixture and factoryfixture
     //                             device groups only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imp-central-api",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imp-central-api",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Electric Imp impCentral API v5 Client",
   "main": "index.js",
   "scripts": {

--- a/spec/device_groups.spec.js
+++ b/spec/device_groups.spec.js
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017-2019 Electric Imp
+// Copyright 2017-2020 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -65,6 +65,36 @@ describe('impCentralAPI.device_groups test suite', () => {
                 expect(res.data.attributes.name).toBe(deviceGroupName);
                 expect(res.data.relationships.product.id).toBe(productId);
                 deviceGroupId = res.data.id;
+                done();
+            }).
+            catch((error) => {
+                done.fail(error);
+            });
+    });
+
+    it('should create a device group with optional attrs', (done) => {
+        const dgName = util.getDeviceGroupName(1);
+        const descr = 'test description';
+        const envVars = {
+            "dataSourceURL" : "https://example.com/v1",
+            "dataSourceAPIVersion" : 1
+        };
+        impCentralApi.deviceGroups.create(
+            productId,
+            DeviceGroups.TYPE_DEVELOPMENT,
+            {
+                name : dgName,
+                description : descr,
+                env_vars : envVars
+            }).
+            then((res) => {
+                expect(res.data.type).toBe(DeviceGroups.TYPE_DEVELOPMENT);
+                expect(res.data.attributes.name).toBe(dgName);
+                expect(res.data.attributes.description).toBe(descr);
+                expect(res.data.attributes.env_vars).toEqual(envVars);
+                return impCentralApi.deviceGroups.delete(res.data.id);
+            }).
+            then((res) => {
                 done();
             }).
             catch((error) => {
@@ -202,12 +232,24 @@ describe('impCentralAPI.device_groups test suite', () => {
 
     it('should update a specific device group', (done) => {
         let descr = 'test description';
+        const envVars = {
+            "dataSourceURL" : "https://example.com/v2",
+            "dataSourceAPIVersion" : 2
+        };
         deviceGroupName = util.getDeviceGroupName(3);
-        impCentralApi.deviceGroups.update(deviceGroupId, DeviceGroups.TYPE_DEVELOPMENT, { description : descr, name: deviceGroupName }).
+        impCentralApi.deviceGroups.update(
+            deviceGroupId,
+            DeviceGroups.TYPE_DEVELOPMENT, 
+            {
+                description : descr,
+                name : deviceGroupName,
+                env_vars : envVars
+            }).
             then((res) => {
                 expect(res.data.id).toBe(deviceGroupId);
                 expect(res.data.attributes.description).toBe(descr);
                 expect(res.data.attributes.name).toBe(deviceGroupName);
+                expect(res.data.attributes.env_vars).toEqual(envVars);
                 done();
             }).
             catch((error) => {


### PR DESCRIPTION
User-defined Environment Variables are supported for Device Group's create() and update() methods (https://developer.electricimp.com/tools/impcentral/environmentvariables).

New tests are added for Device Group's create() and update() with env_vars attribute, all tests are passed successfully.